### PR TITLE
Java 9+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ target/
 .bsp/
 .DS_Store
 *.swp
+.metals/
+.vscode/
+.bloop/
+project/metals.sbt
+project/project/

--- a/src/main/scala/little/sql/Connector.scala
+++ b/src/main/scala/little/sql/Connector.scala
@@ -122,6 +122,7 @@ class Connector(url: String, user: String, password: String, driverClassName: St
   private def createDriver(): Driver =
     classLoader()
       .loadClass(driverClassName)
+      .getDeclaredConstructor()
       .newInstance()
       .asInstanceOf
 


### PR DESCRIPTION
For Java 9+ `.newInstance()` on `Class` is deprecated in favor of `.getDeclaredConstructor().newInstance()`.